### PR TITLE
Enable compiler-docs in patch

### DIFF
--- a/patches/config.toml
+++ b/patches/config.toml
@@ -6,7 +6,7 @@ download-ci-llvm = false
 targets = "AArch64;RISCV;WebAssembly;X86"
 
 [build]
-compiler-docs = false
+compiler-docs = true
 docs = false
 extended = true
 locked-deps = true


### PR DESCRIPTION
Step 06 fails with this error otherwise:
```
Installing: rustc-docs-nightly-x86_64-unknown-linux-gnu
tar: ../../rust/build/dist/rustc-docs-nightly-x86_64-unknown-linux-gnu.tar.xz: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
```

