### PR TITLE
Fixes for macOS

### DIFF
--- a/03-rustc-build.sh
+++ b/03-rustc-build.sh
@@ -2,5 +2,7 @@
 
 set -euo pipefail
 
+source config.sh
+
 cd rust
-python x.py build
+./x build --target $TOOLCHAIN_HOST_TRIPLET --target riscv32em-unknown-none-elf

--- a/04a-link-rustup.sh
+++ b/04a-link-rustup.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 source config.sh
 
-rustup toolchain link $TOOLCHAIN_NAME $(pwd)/rust/build/host/stage1
+rustup toolchain link $TOOLCHAIN_NAME $(pwd)/rust/build/host/stage2

--- a/05-build-dist.sh
+++ b/05-build-dist.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 cd rust
 mkdir -p build/riscv32em-unknown-none-elf/compiler-doc
-python x.py dist
+./x dist

--- a/05-build-dist.sh
+++ b/05-build-dist.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+source config.sh
+
 cd rust
 mkdir -p build/riscv32em-unknown-none-elf/compiler-doc
-./x dist
+./x dist --target $TOOLCHAIN_HOST_TRIPLET --target riscv32em-unknown-none-elf

--- a/06-install-dist.sh
+++ b/06-install-dist.sh
@@ -14,13 +14,13 @@ inst () {
     cd ../../..
 }
 
-inst "rustc-nightly-x86_64-unknown-linux-gnu"
-inst "rust-dev-nightly-x86_64-unknown-linux-gnu"
-inst "rust-std-nightly-x86_64-unknown-linux-gnu"
+inst "rustc-nightly-$TOOLCHAIN_HOST_TRIPLET"
+inst "rust-dev-nightly-$TOOLCHAIN_HOST_TRIPLET"
+inst "rust-std-nightly-$TOOLCHAIN_HOST_TRIPLET"
 inst "rust-std-nightly-riscv32em-unknown-none-elf"
-inst "cargo-nightly-x86_64-unknown-linux-gnu"
+inst "cargo-nightly-$TOOLCHAIN_HOST_TRIPLET"
 inst "rust-src-nightly"
-inst "rustfmt-nightly-x86_64-unknown-linux-gnu"
-inst "clippy-nightly-x86_64-unknown-linux-gnu"
-inst "rustc-docs-nightly-x86_64-unknown-linux-gnu"
+inst "rustfmt-nightly-$TOOLCHAIN_HOST_TRIPLET"
+inst "clippy-nightly-$TOOLCHAIN_HOST_TRIPLET"
+inst "rustc-docs-nightly-$TOOLCHAIN_HOST_TRIPLET"
 inst "rustc-docs-nightly-riscv32em-unknown-none-elf"

--- a/config.sh
+++ b/config.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-export TOOLCHAIN_NAME=rv32e-nightly-2023-04-05-x86_64-unknown-linux-gnu
+export TOOLCHAIN_HOST_TRIPLET=$(rustc --version --verbose | grep 'host: ' | sed -r 's/host: (.*)/\1/')
+export TOOLCHAIN_NAME=rv32e-nightly-2023-04-05

--- a/patches/config.toml
+++ b/patches/config.toml
@@ -1,28 +1,13 @@
 changelog-seen = 2
-profile = "codegen"
+profile = "user"
 
 [llvm]
-download-ci-llvm = false
-targets = "AArch64;RISCV;WebAssembly;X86"
+targets = "AArch64;RISCV;X86"
 
 [build]
 compiler-docs = true
 docs = false
-extended = true
 locked-deps = true
-
-tools = [
-    "cargo",
-    "clippy",
-    "rustdoc",
-    "rustfmt",
-    "src",
-]
-
-target = [
-    "x86_64-unknown-linux-gnu",
-    "riscv32em-unknown-none-elf"
-]
 
 [rust]
 channel = "nightly"
@@ -31,6 +16,7 @@ jemalloc = true
 debuginfo-level-std = 2
 remap-debuginfo = true
 new-symbol-mangling = true
+split-debuginfo = "off"
 
 [dist]
 compression-formats = ["xz"]


### PR DESCRIPTION
- Don't assume python path
- Minimize config by using "user" profile
- Disable `split-debuginfo` (errors out on macOS)
- Dynamically determine host toolchain triplet
- Link stage2 and not stage1 (stage1 misses target libs for me

`-Z build-std=core,alloc` still fails for me with this toolchain. We should check again later when we update to latest rust. Maybe it will be fixed.