### PR TITLE
Point shebangs to `/usr/bin/env bash`

### DIFF
--- a/01-clone.sh
+++ b/01-clone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/02-patch.sh
+++ b/02-patch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/03-clang-build-and-install.sh
+++ b/03-clang-build-and-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/03-rustc-build.sh
+++ b/03-rustc-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/04a-link-rustup.sh
+++ b/04a-link-rustup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/04a-unlink-rustup.sh
+++ b/04a-unlink-rustup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/05-build-dist.sh
+++ b/05-build-dist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/06-install-dist.sh
+++ b/06-install-dist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
This is more generic than relying on the presence of `/bin/bash`.